### PR TITLE
Ocean Spark dependency mgmt

### DIFF
--- a/internal/cmd/ocean/spark_create_cluster.go
+++ b/internal/cmd/ocean/spark_create_cluster.go
@@ -250,8 +250,7 @@ func (x *CmdSparkCreateCluster) installDeps(ctx context.Context) error {
 		dep.WithDryRun(x.opts.DryRun),
 	}
 
-	// Install!
-	return dm.InstallBulk(ctx, dep.DefaultDependencyListKubernetes(), installOpts...)
+	return dm.Install(ctx, dep.DependencyEksctlSpot, installOpts...)
 }
 
 func (x *CmdSparkCreateCluster) doesControllerClusterIDExist(ctx context.Context, controllerClusterID string) (bool, error) {

--- a/internal/dep/defaults.go
+++ b/internal/dep/defaults.go
@@ -19,10 +19,12 @@ var (
 			"v{{.version}}/kops-{{.os}}-{{.arch}}",
 	}
 
+	// Spot fork of eksctl
 	// See: https://github.com/spotinst/weaveworks-eksctl.
-	DependencyEksctl Dependency = &dependency{
-		name:    "eksctl",
-		version: "0.60.0-62eeb9c7",
+	DependencyEksctlSpot Dependency = &dependency{
+		name:               "eksctl-spot",
+		upstreamBinaryName: "eksctl",
+		version:            "0.60.0-62eeb9c7",
 		url: "https://github.com/spotinst/weaveworks-eksctl/releases/download" +
 			"/v{{.version}}/eksctl_{{.os}}_{{.arch}}.tar.gz",
 	}
@@ -34,7 +36,7 @@ func DefaultDependencyListKubernetes() []Dependency {
 	return []Dependency{
 		DependencyKubectl,
 		DependencyKops,
-		DependencyEksctl,
+		DependencyEksctlSpot,
 	}
 }
 

--- a/internal/dep/defaults.go
+++ b/internal/dep/defaults.go
@@ -24,7 +24,7 @@ var (
 	DependencyEksctlSpot Dependency = &dependency{
 		name:               "eksctl-spot",
 		upstreamBinaryName: "eksctl",
-		version:            "0.60.0-62eeb9c7",
+		version:            "0.77.0-6cfea8af",
 		url: "https://github.com/spotinst/weaveworks-eksctl/releases/download" +
 			"/v{{.version}}/eksctl_{{.os}}_{{.arch}}.tar.gz",
 	}

--- a/internal/dep/dependency.go
+++ b/internal/dep/dependency.go
@@ -9,12 +9,20 @@ import (
 )
 
 type dependency struct {
-	name    string
-	version string
-	url     string
+	name               string
+	upstreamBinaryName string
+	version            string
+	url                string
 }
 
 func (x *dependency) Name() string { return x.name }
+
+func (x *dependency) UpstreamBinaryName() string {
+	if x.upstreamBinaryName != "" {
+		return x.upstreamBinaryName
+	}
+	return x.name
+}
 
 func (x *dependency) Version() string { return x.version }
 

--- a/internal/dep/interfaces.go
+++ b/internal/dep/interfaces.go
@@ -24,6 +24,10 @@ type (
 		// Name returns the name of the dependency.
 		Name() string
 
+		// UpstreamBinaryName is the name of the dependency binary that we download.
+		// Can be different from our dependency name.
+		UpstreamBinaryName() string
+
 		// Version returns the version of the dependency.
 		Version() string
 

--- a/internal/dep/interfaces.go
+++ b/internal/dep/interfaces.go
@@ -17,6 +17,9 @@ type (
 
 		// InstallBulk installs a bulk of new dependencies.
 		InstallBulk(ctx context.Context, deps []Dependency, options ...InstallOption) error
+
+		// DependencyPresent determines if a dependency is present
+		DependencyPresent(dep Dependency, options ...InstallOption) (bool, error)
 	}
 
 	// Dependency represents an executable package.

--- a/internal/dep/manager.go
+++ b/internal/dep/manager.go
@@ -85,6 +85,23 @@ func (x *manager) InstallBulk(ctx context.Context, deps []Dependency, options ..
 	return x.installWithSelect(ctx, missing, opts)
 }
 
+func (x *manager) DependencyPresent(dep Dependency, options ...InstallOption) (bool, error) {
+	opts := initDefaultOptions()
+	for _, opt := range options {
+		opt(opts)
+	}
+
+	path := filepath.Join(opts.BinaryDir, dep.Executable())
+	_, err := os.Stat(path)
+	if err != nil && !os.IsNotExist(err) {
+		return false, err
+	}
+
+	present := err == nil
+
+	return present, nil
+}
+
 // shouldInstallDep returns whether we should install a Dependency according to
 // the presence and install policy.
 func shouldInstallDep(installPolicy InstallPolicy, present bool) bool {

--- a/internal/thirdparty/commands/eksctl/eksctl.go
+++ b/internal/thirdparty/commands/eksctl/eksctl.go
@@ -11,7 +11,7 @@ import (
 )
 
 // CommandName is the name of this command.
-const CommandName thirdparty.CommandName = "eksctl"
+const CommandName thirdparty.CommandName = "eksctl-spot"
 
 func init() {
 	thirdparty.Register(CommandName, factory)


### PR DESCRIPTION
- Rename eksctl dependency to `eksctl-spot` to differentiate it from upstream eksctl. This could cause confusion with users.
- Only require eksctl for `ocean spark create cluster` command, the other deps were redundant.
- Bump eksctl-spot version.
- Validate that the required dependencies are installed before proceeding with the cluster creation. The user can choose not to install the deps in the install step.
- Refactor the dependency manager's "is present" checks
- Add dependency version information to the `installBulk` prompt